### PR TITLE
Added JMX arguments to make JMX port known and expose it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ EXPOSE 8080
 # will be used by attached slave agents:
 EXPOSE 50000
 
+# expose the JMX port
+EXPOSE 39999
+
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 
 USER jenkins

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -27,8 +27,14 @@ echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
+# adding explicit JMX arguments to make the JMX port known
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS "$@"
+   exec java $JAVA_OPTS \
+     -Dcom.sun.management.jmxremote=true \
+     -Dcom.sun.management.jmxremote.port=39999 \
+     -Dcom.sun.management.jmxremote.authenticate=false \
+     -Dcom.sun.management.jmxremote.ssl=false \
+     -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image


### PR DESCRIPTION
- Sets JMX to use a fixed port
- disables authentication and SSL on the assumption that access is only possible from the EC2 where the container is running.
