### PR TITLE
Install LXC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get install -y python-dev python-pip
 #
 RUN apt-get install -y ruby ruby-dev gem debhelper devscripts dh-apparmor \
     gem2deb gettext intltool-debian libcroco3 libjs-jquery libunistring0 \
-    po-debconf ruby-minitest rubygems-integration
+    po-debconf ruby-minitest rubygems-integration \
+    lxc
 
 RUN pip install --upgrade pip virtualenv virtualenvwrapper
 RUN gem install bundler thor json hipchat excon httparty nokogiri \


### PR DESCRIPTION
Newer versions of Docker are dynamically linked, meaning that errors
such as,

/usr/bin/docker: error while loading shared libraries: libapparmor.so.1:
cannot open shared object file: No such file or directory

will occur. This change ensures that the container has the appropriate
libraries installed by installing the lxc package.