### PR TITLE
Drop deprecated java base image for openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 #
 # This line was inherited from the original repo. It has been left
@@ -23,8 +23,8 @@ RUN apt-get install -y ruby ruby-dev gem debhelper devscripts dh-apparmor \
     lxc
 
 RUN pip install --upgrade pip virtualenv virtualenvwrapper
-RUN gem install bundler thor json hipchat excon httparty nokogiri \
-    jenkins_api_client
+RUN gem install --no-rdoc --no-ri \
+  bundler thor json hipchat excon httparty nokogiri jenkins_api_client
 
 ENV JENKINS_HOME /srv/jenkins
 ENV JENKINS_SLAVE_AGENT_PORT 50000


### PR DESCRIPTION
This base image is officially deprecated in favor of the openjdk image,
and will receive no further updates after 2016-12-31 (Dec 31, 2016).
Making the change also fixes the breakage due to the mixlib gem requiring
ruby greater than the 2.1 version supplied by the deprecated java base
as the openjdk image comes with 2.3.